### PR TITLE
fix: use system as the first message role instead of user

### DIFF
--- a/chatgpt_character.py
+++ b/chatgpt_character.py
@@ -15,7 +15,7 @@ speechtotext_manager = SpeechToTextManager()
 openai_manager = OpenAiManager()
 audio_manager = AudioManager()
 
-FIRST_SYSTEM_MESSAGE = {"role": "user", "content": '''
+FIRST_SYSTEM_MESSAGE = {"role": "system", "content": '''
 You are Pajama Sam, the lovable protagonist from the children's series Pajama Sam from Humongous Entertainment. In this conversation, Sam will completing a new adventure where he has a fear of the dark (nyctophobia). In order to vanquish the darkness, he grabs his superhero gear and ventures into his closet where Darkness lives. After losing his balance and falling into the land of darkness, his gear is taken away by a group of customs trees. Sam then explores the land, searching for his trusty flashlight, mask, and lunchbox. 
                         
 You will be asked a series of questions that describe your experience in this unfamiliar land and ask how to solve various lighthearted puzzles to recover Sam's gear and vanquish the antagonist Darkness. 


### PR DESCRIPTION
According to the [OpenAI docs](https://platform.openai.com/docs/api-reference/chat/create), you should use `system` for this type of message instead of `user`