### PR TITLE
Fix broken azure package in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-azure_storage_blob==12.19.0
+azure-cognitiveservices-speech==12.19.0
 elevenlabs==0.2.8
 keyboard==0.13.5
 mutagen==1.46.0


### PR DESCRIPTION
Right now I am getting error when running azure_speech_to_text.py:
```
Traceback (most recent call last):
  File "C:\Users\barte\PycharmProjects\pythonProject\main.py", line 2, in <module>
    import azure.cognitiveservices.speech as speechsdk
ModuleNotFoundError: No module named 'azure.cognitiveservices.speech'
```
After installing the other package it works.
Blob only contains those modules:

<img width="230" alt="image" src="https://github.com/DougDougGithub/Babagaboosh/assets/145470652/7380f325-1af6-4b02-a52b-c0174cef0408">

with cognitive module being empty installing the other package results in 
<img width="263" alt="image" src="https://github.com/DougDougGithub/Babagaboosh/assets/145470652/0e2ccf1d-47d4-463a-9edc-e2f47b8c3fde">
