### PR TITLE
Fixed requirements.txt AGAIN

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+azure-cognitiveservices-speech==1.34.0
 azure_storage_blob==12.19.0
 elevenlabs==0.2.8
 keyboard==0.13.5


### PR DESCRIPTION
Currently when trying to run .\chatgpt_character.py
It throws the error below.
Adding azure-cognitiveservices-speech to requirements.txt fix it.

Traceback (most recent call last):
  File "C:\Users\anton\repos\Babagaboosh\chatgpt_character.py", line 4, in <module>
    from azure_speech_to_text import SpeechToTextManager
  File "C:\Users\anton\repos\Babagaboosh\azure_speech_to_text.py", line 2, in <module>
    import azure.cognitiveservices.speech as speechsdk
ModuleNotFoundError: No module named 'azure.cognitiveservices'