### PR TITLE
Fix azure-cognitiveservices-speech version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-azure-cognitiveservices-speech==12.19.0
+azure-cognitiveservices-speech==1.34.0
 elevenlabs==0.2.8
 keyboard==0.13.5
 mutagen==1.46.0


### PR DESCRIPTION
ERROR: Could not find a version that satisfies the requirement azure-cognitiveservices-speech==12.19.0 (from versions: 1.20.0, 1.21.0, 1.22.0, 1.23.0, 1.24.0, 1.24.1, 1.24.2, 1.25.0, 1.25.1b1, 1.26.0, 1.27.0, 1.28.0, 1.29.0, 1.30.0, 1.31.0, 1.32.1, 1.33.0, 1.34.0)
ERROR: No matching distribution found for azure-cognitiveservices-speech==12.19.0