### PR TITLE
Fix installation, add missing ENV errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+ChatHistoryBackup.txt

--- a/azure_speech_to_text.py
+++ b/azure_speech_to_text.py
@@ -11,8 +11,12 @@ class SpeechToTextManager:
     def __init__(self):
         # Creates an instance of a speech config with specified subscription key and service region.
         # Replace with your own subscription key and service region (e.g., "westus").
-         self.azure_speechconfig = speechsdk.SpeechConfig(subscription=os.getenv('AZURE_TTS_KEY'), region=os.getenv('AZURE_TTS_REGION'))
-         self.azure_speechconfig.speech_recognition_language="en-US"
+        try:
+            self.azure_speechconfig = speechsdk.SpeechConfig(subscription=os.getenv('AZURE_TTS_KEY'), region=os.getenv('AZURE_TTS_REGION'))
+        except TypeError:
+            exit("Ooops! You forgot to set AZURE_TTS_KEY or AZURE_TTS_REGION in your environment!")
+        
+        self.azure_speechconfig.speech_recognition_language="en-US"
         
     def speechtotext_from_mic(self):
         

--- a/eleven_labs.py
+++ b/eleven_labs.py
@@ -2,7 +2,10 @@ from elevenlabs import generate, stream, set_api_key, voices, play, save
 import time
 import os
 
-set_api_key(os.getenv('ELEVENLABS_API_KEY'))
+try:
+  set_api_key(os.getenv('ELEVENLABS_API_KEY'))
+except TypeError:
+  exit("Ooops! You forgot to set ELEVENLABS_API_KEY in your environment!")
 
 class ElevenLabsManager:
 

--- a/obs_websockets.py
+++ b/obs_websockets.py
@@ -2,6 +2,8 @@ import time
 from obswebsocket import obsws, requests  # noqa: E402
 from websockets_auth import WEBSOCKET_HOST, WEBSOCKET_PORT, WEBSOCKET_PASSWORD
 
+# This is extremely insecure, please for the love of God don't use this in production
+
 ##########################################################
 ##########################################################
 

--- a/openai_chat.py
+++ b/openai_chat.py
@@ -26,7 +26,10 @@ class OpenAiManager:
     
     def __init__(self):
         self.chat_history = [] # Stores the entire conversation
-        self.client = OpenAI(api_key=os.environ['OPENAI_API_KEY'])
+        try:
+            self.client = OpenAI(api_key=os.environ['OPENAI_API_KEY'])
+        except TypeError:
+            exit("Ooops! You forgot to set OPENAI_API_KEY in your environment!")
 
     # Asks a question with no chat history
     def chat(self, prompt=""):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-azure_storage_blob==12.19.0
+azure-cognitiveservices-speech==1.34.0
 elevenlabs==0.2.8
 keyboard==0.13.5
 mutagen==1.46.0
 obs_websocket_py==1.0
 openai==1.7.2
-pygame==2.3.0
+pydantic==1.10.13
 pygame_ce==2.3.0
 rich==13.7.0
 soundfile==0.12.1


### PR DESCRIPTION
- Fix required Azure speech package version
- Only install pygame-ce (not original pygame), they are redundant to each other
- Fix installation by forcing Pydantic 1 (v2 doesn't work)
- Print errors and exit when missing ENV variables so it's easier to understand
- Add gitignore file to prevent committing python package cache or chat logs

You should consider [using "dotenv"](https://dev.to/jakewitcher/using-env-files-for-environment-variables-in-python-applications-55a1) to load environment variables from a file called '.env', and provide and example file with dummy values at '.env.example' so people don't have to open up Windows settings, and can instead edit a text file. Or don't idk